### PR TITLE
Fixes #71 Changed default example - made selected color text always be grey

### DIFF
--- a/src/components/Banner/Banner.jsx
+++ b/src/components/Banner/Banner.jsx
@@ -78,11 +78,11 @@ const Banner = () => {
   const [textSize, setTextSize] = useState(28);
 
   // Set the initial team and name
-  const initialTeam = teams.find(team => team.name === 'Chicago Bears');
+  const initialTeam = teams.find(team => team.name === 'Cincinnati Bengals');
   const [selectedTeam, setSelectedTeam] = useState(initialTeam.logo);
   const [teamName, setTeamName] = useState(initialTeam.name);
 
-  const [fontColor, setFontColor] = useState('#FFF');
+  const [fontColor, setFontColor] = useState('#FFFFFF');
   const [bannerColor, setBannerColor] = useState('#FB4F14');
   
   function setBannerWidth(event) {

--- a/src/components/ColorPicker/ColorPicker.jsx
+++ b/src/components/ColorPicker/ColorPicker.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-const ColorPicker = ({ value, setValue, defaultColor, label }) => {
+const ColorPicker = ({ value, setValue, label }) => {
   return (
     <div className="mb-4">
       <label htmlFor={`${label}-colorPicker`} className="mb-2 font-bold block">
@@ -14,7 +14,7 @@ const ColorPicker = ({ value, setValue, defaultColor, label }) => {
         className="w-full bg-gray-200 rounded-lg cursor-pointer px-2 py-1 mb-2"
       />
       <p className="mt-2">
-        Selected color: <span style={{ color: defaultColor }}>{defaultColor}</span>
+        Selected color: <span style={{ color: '#333', textTransform: 'uppercase' }}>{value}</span>
       </p>
     </div>
   );


### PR DESCRIPTION
Selected color text being the color is selected has an issue if it's white or a very light color you cannot read it. So It's just grey all the time